### PR TITLE
Update example in README to show use of SDK module

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ await myArchive.writeFile('/example.txt', 'Hello World!')
 ## API/Examples (Callbacks)
 
 ```js
-const SDK = require('../')
+const SDK = require('dat-sdk')
 const { Hypercore, Hyperdrive, resolveName, deleteStorage, destroy } = SDK()
 
 const archive = Hyperdrive(null, {


### PR DESCRIPTION
The first example properly shows the require statement for this module, but the 2nd example is using a relative path that is not consistent with the other example or how users in the wild would implement this project.