### PR TITLE
Added docs about webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,29 @@ trie.put('key', 'value', () => {
 
 ```
 
+## Examples (webpack.config.js)
+
+To bundle with webpack instead of browserify, resolve the `fs` module with the `graceful-fs` module.
+
+```js
+const path = require('path')
+
+module.exports = {
+  entry: './src/dat.js',
+  target: 'web',
+  resolve: {
+    alias: {
+      fs: 'graceful-fs'
+    }
+  },
+  output: {
+    filename: 'dat.js',
+    path: path.resolve(__dirname, 'dist')
+  }
+}
+
+```
+
 ## API (Promise)
 
 ### `const {DatArchive, destroy} = SDK({ storageOpts, swarmOpts, driveOpts, coreOpts, dnsOpts })`


### PR DESCRIPTION
This commit provides a webpack config for a bundle similiar to browserify.

Browserify bundles to an empty function for `fs`, and for each module declares
`fs` as a `graceful-fs` require.

https://benclinkinbeard.com/posts/how-browserify-works/

The webpack bundle built from this commit's config resolves `graceful-fs`
as an alias to `fs`.

`fs` used in dat-sdk/index for browser/hyperdrive IO:

https://github.com/random-access-storage/random-access-web