### PR TITLE
fix: getSecretKey returns actual secret key

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -192,7 +192,7 @@ module.exports = function SDK (opts) {
 
     async getSecretKey () {
       await this._loadPromise
-      return this._archive.secretKey
+      return this._archive.metadata.secretKey
     }
 
     async getInfo (opts = {}) {


### PR DESCRIPTION
Fixes #45.

Not sure when this broke, but given that the repo depends on [a git branch of hyperdrive](https://github.com/datproject/sdk/blob/master/package.json#L42) it seems likely that a hyperdrive change broke it.

Perhaps also consider switching to depend on a stable version of hyperdrive (maybe a commit or tag rather than a branch name?)