### PR TITLE
Pin sodium-universal to 3.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ git clone git@github.com:datproject/sdk.git
 
 cd sdk
 
+# Install dependencies
+npm install
+
 # Compile the SDK into a single JS file
 npm run build
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "hyperswarm": "^2.15.2",
     "hyperswarm-web": "^2.1.1",
     "random-access-application": "^1.0.0",
-    "random-access-memory": "^3.1.1"
+    "random-access-memory": "^3.1.1",
+    "sodium-universal": "3.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
A temp. fix for #72

This pins sodium-universal to 3.0.2 which will modify the version used by other dependencies.

npm ls sodium-universal currently shows

    hyper-sdk@3.0.2
    ├─┬ hypercore-crypto@2.2.0
    │ └── sodium-universal@3.0.3
    └─┬ hypercore-protocol@8.0.7
      └─┬ simple-hypercore-protocol@2.1.1
        └─┬ noise-protocol@3.0.1
          ├─┬ hmac-blake2b@2.0.0
          │ └── sodium-universal@3.0.3  deduped
          └── sodium-universal@3.0.3  deduped

and becomes with this change

    hyper-sdk@3.0.2
    ├─┬ hypercore-crypto@2.2.0
    │ └── sodium-universal@3.0.2  deduped
    ├─┬ hypercore-protocol@8.0.7
    │ └─┬ simple-hypercore-protocol@2.1.1
    │   └─┬ noise-protocol@3.0.1
    │     ├─┬ hmac-blake2b@2.0.0
    │     │ └── sodium-universal@3.0.2  deduped
    │     └── sodium-universal@3.0.2  deduped
    └── sodium-universal@3.0.2

The only difference I see between 3.0.2 and 3.0.3 is an update to the version of sodium-javascript being used.
