### PR TITLE
Browser Bundle: use window.hyperSDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run build
 ```html
 <script src="hyper-sdk-bundle.js"></script>
 <script>
-  const SDK = window.datSDK
+  const SDK = window.hyperSDK
   // Look at the examples from here
 </script>
 ```


### PR DESCRIPTION
at least with 3.0.3, window.datSDK has been replaced by window.hyperSDK

