### PR TITLE
When closing wait for cores and drives to be closed

### DIFF
--- a/sdk.js
+++ b/sdk.js
@@ -82,16 +82,22 @@ async function SDK (opts = {}) {
   }
 
   function close (cb) {
+    let pending = 1
     for (const drive of drives.values()) {
-      drive.close()
+      ++pending
+      drive.close(onclose)
     }
-
     for (const core of cores.values()) {
-      core.close()
+      ++pending
+      core.close(onclose)
     }
+    onclose()
 
-    if (handlers.close) handlers.close(cb)
-    else cb()
+    function onclose () {
+      if (--pending !== 0) return
+      if (handlers.close) handlers.close(cb)
+      else cb()
+    }
   }
 
   function resolveName (url, cb) {

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,7 @@ async function run (createTestSDKs, name) {
   test.onFinish(() => {
     close(() => {
       close2(() => {
-        setTimeout(cleanup, 100)
+        process.nextTick(cleanup)
       })
     })
   })


### PR DESCRIPTION
Otherwise, the hyperspace connection might be closed while still trying to send messages over the RPC connection, resulting in errors.

This allows to remove a timeout that was present in the test to suppress these errors.