### PR TITLE
chore: remove unused hypercore-protocol dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-sdk",
-  "version": "6.2.2",
+  "version": "6.2.1",
   "description": "A Software Development Kit for the Hypercore-Protocol",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-sdk",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "A Software Development Kit for the Hypercore-Protocol",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:bare": "bare test.js",
     "test:node": "node test.js",
     "lint": "standard --fix && tsc",
-    "upgrade-hyper": "npm i --save corestore@latest hypercore@latest hyperswarm@latest hyperdrive@latest hyperbee@latest hypercore-protocol@latest z32@latest b4a@latest bare-events@latest bare-fetch@latest bare-os@latest bare-path@latest bare-stream@latest"
+    "upgrade-hyper": "npm i --save corestore@latest hypercore@latest hyperswarm@latest hyperdrive@latest hyperbee@latest z32@latest b4a@latest bare-events@latest bare-fetch@latest bare-os@latest bare-path@latest bare-stream@latest"
   },
   "repository": {
     "type": "git",
@@ -57,7 +57,6 @@
     "dns-query": "^0.11.2",
     "hyperbee": "^2.26.5",
     "hypercore": "^11.20.1",
-    "hypercore-protocol": "^8.0.7",
     "hyperdrive": "^13.0.2",
     "hyperswarm": "^4.16.0",
     "rocksdb-native": "^3.5.10",


### PR DESCRIPTION
`hypercore-protocol@^8.0.7` is still listed as a dependency in hyper-sdk but is never imported or used anywhere in the codebase -- it's a leftover from before `hypercore@11.x` internalized the protocol layer. It pulls in `hypercore-crypto@2.x` -> `sodium-universal@3.x` -> `sodium-native@^3.2.0`, which conflicts with the rest of the ecosystem's `sodium-native@5.x` and causes segfaults in Electron on Linux.

Once merged and released, we should bump its version to `6.2.2` in `hypercore-fetch` https://github.com/RangerMauve/hypercore-fetch/